### PR TITLE
Configured build step to run automatically when installing with Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "src/index.d.ts",
   "description": "React Native Calendar Components",
   "scripts": {
-    "build": "yarn build:tsc && yarn build:docs",
+    "build": "yarn build:ts && yarn build:docs",
     "build:ts": "tsc",
     "build:dev": "tsc --noEmit",
     "build:docs": "node ./scripts/build-docs.js",
@@ -21,7 +21,8 @@
     "android": "react-native run-android",
     "xcode": "open ios/CalendarsExample.xcworkspace/",
     "clean": "rm yarn-lock && rm -rf ./node_modules && yarn",
-    "pod-install": "pod install --project-directory=ios"
+    "pod-install": "pod install --project-directory=ios",
+    "prepare": "yarn build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Context
- The primary goal of this PR is to run build process when installing the package with yarn so that compiled code can be available in node_modules rather than entire repositry

### Figma
- No Figma design

## Description of the Solution

### How did you solve the problem?
- By adding an extra script command prepare which will run and compile build files for react-native-calendar in the destination project after the package is downloaded in the destination app.

### What are the tradeoffs that reviewers of this PR should be aware of?
- This is just simple script update so there are no tradeoffs for for this feature

### What can go wrong if we merge in this PR from a security perspective?
-No impact on security perspective as it is just a build script

### What can go wrong if we merge in this PR from a performance perspective?
-No Impact on performance

## Screenshots/Videos

### Before Fix
No UI changes or feature changes

### After Fix (Android)
No UI changes or feature changes

### After Fix (iOS)
No UI changes or feature changes

## Quality Assurance Checklist

[X] Changes are tested and verified on both Android and iOS.
[X] Relevant tags are added to the PR. (enhancement, bug, performance, refactor)
[X] This PR description is completely filled out and all placeholders are either replaced or removed.
[X] I understand I can strikethrough checklist items (like this) that are not applicable to this PR.