### PR TITLE
Br/fix marking style

### DIFF
--- a/src/calendar/day/marking/index.tsx
+++ b/src/calendar/day/marking/index.tsx
@@ -48,19 +48,38 @@ export interface MarkingProps extends DotProps {
   customTextStyle?: StyleProp<TextStyle>;
   customContainerStyle?: StyleProp<ViewStyle>;
   dotColor?: string;
-  // START: New properties for border customization and overlapping period handling
+
+  // Border customization properties
   borderWith?: number;
   borderRadius?: number;
   borderColor?: string;
+
+  // Multi-period handling
   isMultiPeriod?: boolean;
+
+  // Legacy 2-section properties (for backward compatibility)
   startPeriodColor?: string;
   endPeriodColor?: string;
   startPeriodBorderColor?: string;
   endPeriodBorderColor?: string;
-  // END: New properties for border customization and overlapping period handling
-  //multi-dot
+
+  // 3-section properties for enhanced layout
+  leftSectionColor?: string;
+  leftSectionBorderColor?: string;
+  middleSectionColor?: string;
+  middleSectionBorderColor?: string;
+  rightSectionColor?: string;
+  rightSectionBorderColor?: string;
+
+  // Edge case handling properties for single-day periods
+  leftSectionIsSingleDay?: boolean;
+  rightSectionIsSingleDay?: boolean;
+  middleSectionIsSingleDay?: boolean;
+
+  // Multi-dot
   dots?: DOT[];
-  //multi-period
+
+  // Multi-period
   periods?: PERIOD[];
   startingDay?: boolean;
   endingDay?: boolean;


### PR DESCRIPTION
## Context

- The purpose of this PR is to implement and validate styling for rulings within the calendar and remove spacing , also the implementation of 3 rulings in a single day. 

### Figma
![image (3)](https://github.com/user-attachments/assets/9f6dd46a-5c10-41c3-8a38-ba7c344c4786)
![image (2)](https://github.com/user-attachments/assets/a8243a8a-dc87-43b1-b2c6-aca6c906ce94)

## Description of the Solution

### How did you solve the problem?

- Introduced new styling properties (middleFillerStyles like it was in left and right filler .) in `wix fork` to support visual differentiation of calendar periods.
- Ensured proper merging of overlapping date ranges to preserve startingDay and endingDay flags without losing previous styles.
- Applied consistent text color, background color, and custom container styles based on the ruling type.
- Validated that all rulings render accurately on both iOS and Android across different ranges.

### What are the tradeoffs that reviewers of this PR should be aware of?

- This PR cannot be fully tested until the `br/fix-marking-style` branch from the` Wix fork` is merged into the development branch.
- The styling is not completed yet, there is still few styles left like icon and text alignment etc.

---

## Quality Assurance Checklist

- [X] Changes are tested and verified on both Android and iOS.
- [X] Relevant tags are added to the PR. (enhancement, bug, performance, refactor)
- [X] This PR description is completely filled out and all placeholders are either replaced or removed.
- [X] I understand I can strikethrough checklist items (~~like this~~) that are not applicable to this PR.
